### PR TITLE
Adding "Total" to usage summary

### DIFF
--- a/ps_mem.py
+++ b/ps_mem.py
@@ -420,7 +420,7 @@ def print_memory_usage(sorted_cmds, shareds, count, total):
                           human(shareds[cmd[0]]), human(cmd[1]),
                           cmd_with_count(cmd[0], count[cmd[0]])))
     if have_pss:
-        sys.stdout.write("%s\n%s%8sB\n%s\n" %
+        sys.stdout.write("%s\n%s%8sB\tTotal\n%s\n" %
                          ("-" * 33, " " * 24, human(total), "=" * 33))
 
 def verify_environment():


### PR DESCRIPTION
String "Total" added for grep-like purposes and visibility.
Output:
                          9.2 GiB       Total

Example purpose:
for i in `who | awk {'print $1'} | grep -v root | sort | uniq`; do echo $i | tr -d "\n"; ./ps_mem.py -p $(pgrep -u $i | paste -d, -s) | grep Total; done
