### PR TITLE
Show swap info, and optionaly (-d) display the pid

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ can be run directly.
 Usage:
 
 ```
-ps_mem [-h|--help] [-p PID,...] [-s|--split-args] [-t|--total] [-w N]
+ps_mem [-h|--help] [-p PID,...] [-s|--split-args] [-t|--total] [-w N] [-d|--discriminate-by-pid] [-S|--swap]
 ```
 
 Example output:
@@ -47,3 +47,14 @@ for i in $(ps -e -o user= | sort | uniq); do
   printf '%-20s%10s\n' $i $(sudo ps_mem --total -p $(pgrep -d, -u $i))
 done
 ```
+
+*Added options*:
+
+-S | --swap  To show swap information of each program and the total
+             swap. It is recovered from /proc/<pid>/smaps. Also, if
+             the kernel supports SwapPss, it prints the Shared Swap
+             information of each Program (Note that Swap - SwapPss
+             is not Private Swap) and the total of Shared Swap.
+
+-d | --discriminate-by-pid  Discriminate by process id, and do not
+                            group by program

--- a/ps_mem.py
+++ b/ps_mem.py
@@ -465,10 +465,17 @@ def get_memory_usage(pids_to_show, split_args, discriminate_by_pid,
 
     # Total swaped mem for each program
     total_swap = 0
+<<<<<<< 26f3d76f6c53b237121017b14b5b9ddc9383ed68
 
     # Total swaped shared mem for each program
     total_shared_swap = 0
 
+=======
+
+    # Total swaped shared mem for each program
+    total_shared_swap = 0
+
+>>>>>>> Add Swap support as an option:
     # Add shared mem for each program
     total = 0
 
@@ -492,6 +499,7 @@ def get_memory_usage(pids_to_show, split_args, discriminate_by_pid,
     return sorted_cmds, shareds, count, total, swaps, shared_swaps, \
         total_swap, total_shared_swap
 
+<<<<<<< 26f3d76f6c53b237121017b14b5b9ddc9383ed68
 
 def print_header(show_swap, discriminate_by_pid):
     output_string = " Private  +   Shared  =  RAM used"
@@ -506,6 +514,22 @@ def print_header(show_swap, discriminate_by_pid):
     sys.stdout.write(output_string)
 
 
+=======
+
+def print_header(show_swap, discriminate_by_pid):
+    output_string = " Private  +   Shared  =  RAM used"
+    if show_swap:
+        if have_swap_pss:
+            output_string += " " * 5 + "Shared Swap"
+        output_string += "   Swap used"
+    output_string += "\tProgram"
+    if discriminate_by_pid:
+        output_string += "[pid]"
+    output_string += "\n\n"
+    sys.stdout.write(output_string)
+
+
+>>>>>>> Add Swap support as an option:
 def print_memory_usage(sorted_cmds, shareds, count, total, swaps, total_swap,
                        shared_swaps, total_shared_swap, show_swap):
     for cmd in sorted_cmds:


### PR DESCRIPTION
The Swap information is retrieved from the `/proc/<pid>/status`
file, particularly from the **VmSwap** parameter.

Also, with the `-d` parameter, it shows the **pid** of each process.
The discrimination is performed just as a better alternative to the
`-s` parameter, without it, the total of swap result will not be equals
to the total swap space used in the system.