### PR TITLE
Flush the stdout.

### DIFF
--- a/ps_mem.py
+++ b/ps_mem.py
@@ -469,6 +469,8 @@ def main():
                     sys.stdout.write(human(total, units=1)+'\n')
                 elif not only_total:
                     print_memory_usage(sorted_cmds, shareds, count, total)
+
+                sys.stdout.flush()
                 time.sleep(watch)
             else:
                 sys.stdout.write('Process does not exist anymore.\n')


### PR DESCRIPTION
When the program run through a pipe, the stdout is not flushed; for example
the following line do not output nothing

    $ sudo ps_mem -t -w 1 | cat