### PR TITLE
Add no-humanize and remove root verification

### DIFF
--- a/ps_mem.py
+++ b/ps_mem.py
@@ -539,11 +539,6 @@ def print_memory_usage(sorted_cmds, shareds, count, total, swaps, total_swap,
 
 
 def verify_environment():
-    if os.geteuid() != 0:
-        sys.stderr.write("Sorry, root permission required.\n")
-        sys.stderr.close()
-        sys.exit(1)
-
     try:
         kernel_ver()
     except (IOError, OSError):


### PR DESCRIPTION
This PR adds a `--no-humanize` flag to allow writing the ps_mem output in a machine a machine parsable form (e.g. useful for later graphing the data in matplotlib). 

Also I believe the `root` user verification is an artifact of some older code? As long as the process running is owned by the user ps_mem run by the user will have access to the appropriate proc files. 

On a side-note I'm quite curious as to the point of the `if pss` branch in `print_memory_usage` -- here is the difference in output with the code present and with the code commented out:

```
 28.2 MiB +   2.5 MiB =  30.6 MiB	nm-applet
---------------------------------
                         30.6 MiB
=================================
 28.2 MiB +   2.5 MiB =  30.6 MiB	nm-applet
---------------------------------
                         30.6 MiB
```
vs. 

```
 28.2 MiB +   2.5 MiB =  30.6 MiB	nm-applet
 28.2 MiB +   2.5 MiB =  30.6 MiB	nm-applet
 28.2 MiB +   2.5 MiB =  30.6 MiB	nm-applet
```

It's really hard for me to tell what the delimiter lines are adding here.. Perhaps the entire branch should be pruned? 