### PR TITLE
Changing options parsing library from getopts to argparse

### DIFF
--- a/ps_mem.py
+++ b/ps_mem.py
@@ -178,8 +178,8 @@ def parse_options():
             options.pids_to_show = [int(pid) for pid in
                                     options.pids_to_show.split(',')]
         except:
-                sys.stderr.write(help())
-                sys.exit(3)
+            sys.stderr.write(help())
+            sys.exit(3)
 
     if options.watch is not None:
         if options.watch < 0:

--- a/ps_mem.py
+++ b/ps_mem.py
@@ -146,12 +146,12 @@ proc = Proc()
 
 def parse_options():
     """
-    Parses options given after program call.
+    Parses any options given after calling the program.
 
     Returns:
-        Tuple of:
+        Tuple with elements:
             split_args - type boolean,
-            pids_to_show - type list or nonetype,
+            pids_to_show - type list of ints or nonetype,
             watch - type float or nonetype,
             total - type boolean,
             discriminate_by_pid - type boolean,
@@ -172,7 +172,7 @@ def parse_options():
     parser.add_argument('-w', '--watch', nargs='?', const=2, type=float)
 
     options = parser.parse_args()
-    # Convert string of '<pid1>, <pid2>,..<pidN>' to list.
+    # Convert string of '<pid1>, <pid2>,..<pidN>' to list of ints.
     if options.pids_to_show is not None:
         try:
             options.pids_to_show = [int(pid) for pid in

--- a/test.py
+++ b/test.py
@@ -1,0 +1,8 @@
+import argparse
+import sys
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--foo', nargs='+')
+a = parser.parse_args('--foo'.split())
+print(a)

--- a/test.py
+++ b/test.py
@@ -1,8 +1,0 @@
-import argparse
-import sys
-
-
-parser = argparse.ArgumentParser()
-parser.add_argument('--foo', nargs='+')
-a = parser.parse_args('--foo'.split())
-print(a)


### PR DESCRIPTION
From the getopt python docs(https://docs.python.org/3/library/getopt.html):

"Note The getopt module is a parser for command line options whose API is designed to be familiar to users of the C getopt() function. Users who are unfamiliar with the C getopt() function or who would like to write less code and get better help and error messages should consider using the argparse module instead."

Argparse has many benefits over getopt both currently, and for any future implementations. These include:

- handling positional arguments
- supports sub-commands
- alternative option prefixes like + and /
- handles style arguments
- informative usage messages and a simple interface for custom types and actions
- allows easy implementation of mutually exclusive arguments
- allows easy implementation of default argument values

The main advantages are clarity for the user, code readability, and code maintainability. With argparse, the complexity required for adding new features is much lower.

For example, a default value of 2 seconds for the -w|--watch option was added with the simple arguments `nargs='?', const=2` to the add_argument() method in argparse:

`parser.add_argument('-w', '--watch', nargs='?', const=2, type=float).`

Type checking is also easily done with the `type=float` argument for add_argument(), complete with inbuilt error messages. Previously, entering `sudo ps_mem -w foo` would return the help message without any context. Now it returns the help message in addition to:

`ps_mem: error: argument -w/--watch: invalid float value: 'foo'`