### PR TITLE
fix missing processes whose commandline isn't executable and parent is inaccessible

### DIFF
--- a/ps_mem.py
+++ b/ps_mem.py
@@ -363,9 +363,13 @@ def getCmdName(pid, split_args, discriminate_by_pid, exe_only=False):
                 ppid = int(ps_line[6:-1])
                 break
         if ppid:
-            p_exe = getCmdName(ppid, False, False, exe_only=True)
-            if exe == p_exe:
-                cmd = exe
+            try:
+                p_exe = getCmdName(ppid, False, False, exe_only=True)
+            except LookupError:
+                pass
+            else:
+                if exe == p_exe:
+                    cmd = exe
     if sys.version_info >= (3,):
         cmd = cmd.encode(errors='replace').decode()
     if discriminate_by_pid:


### PR DESCRIPTION
```
$ ./ps_mem.py -p 2785185                                               
 Private  +   Shared  =  RAM used   Program

$ ./ps_mem.py -p 2785185 -s
 Private  +   Shared  =  RAM used   Program

  2.4 GiB +  15.9 MiB =   2.4 GiB   /usr/bin/python3 /usr/bin/qutebrowser --no-err-windows
---------------------------------
                          2.4 GiB
=================================
```

Fixed:
```
$ ./ps_mem.py -p 2785185   
 Private  +   Shared  =  RAM used   Program

  2.4 GiB +  15.9 MiB =   2.4 GiB   qutebrowser
---------------------------------
                          2.4 GiB
=================================
```