### PR TITLE
ps_mem shows unwanted blank spaces

### DIFF
--- a/ps_mem.py
+++ b/ps_mem.py
@@ -311,7 +311,7 @@ def getMemStats(pid):
 
 def getCmdName(pid, split_args, discriminate_by_pid, exe_only=False):
     cmdline = proc.open(pid, 'cmdline').read().split("\0")
-    if cmdline[-1] == '' and len(cmdline) > 1:
+    while cmdline[-1] == '' and len(cmdline) > 1:
         cmdline = cmdline[:-1]
 
     path = proc.path(pid, 'exe')


### PR DESCRIPTION
Kernel inserts way too many unnecessary null signs at the end of cmdline proc file for some processes (e.g. sshd when logged via ssd). These are not filtered out during cmdline handling.  
(rhbz#1780986)