### PR TITLE
Move from getopt to argparse

### DIFF
--- a/ps_mem.py
+++ b/ps_mem.py
@@ -73,11 +73,11 @@
 # FreeBSD is supported if linprocfs is mounted at /compat/linux/proc/
 # FreeBSD 8.0 supports up to a level of Linux 2.6.16
 
-import getopt
 import time
 import errno
 import os
 import sys
+import argparse
 
 # The following exits cleanly on Ctrl-C or EPIPE
 # while treating other exceptions as before.
@@ -147,67 +147,63 @@ proc = Proc()
 #
 
 def parse_options():
-    try:
-        long_options = [
-            'split-args',
-            'help',
-            'version',
-            'total',
-            'discriminate-by-pid',
-            'swap'
-        ]
-        opts, args = getopt.getopt(sys.argv[1:], "shtdSp:w:", long_options)
-    except getopt.GetoptError:
-        sys.stderr.write(help())
-        sys.exit(3)
+    help_msg = 'Show program core memory usage.'
+    parser = argparse.ArgumentParser(prog='ps_mem', description=help_msg)
+    parser.add_argument('--version', action='version', version='3.13')
+    parser.add_argument(
+        '-s', '--split-args',
+        action='store_true',
+        help='Show and separate by, all command line arguments',
+    )
+    parser.add_argument(
+        '-t', '--total',
+        dest='only_total',
+        action='store_true',
+        help='Show only the total value',
+    )
+    parser.add_argument(
+        '-d', '--discriminate-by-pid',
+        action='store_true',
+        help='Show by process rather than by program',
+    )
+    parser.add_argument(
+        '-S', '--swap',
+        dest='show_swap',
+        action='store_true',
+        help='Show swap information',
+    )
+    parser.add_argument(
+        '-p',
+        dest='pids',
+        metavar='<pid>[,pid2,...pidN]',
+        help='Only show memory usage PIDs in the specified list',
+    )
+    parser.add_argument(
+        '-w',
+        dest='watch',
+        type=int,
+        help='Measure and show process memory every N seconds',
+    )
+    args = parser.parse_args()
 
-    if len(args):
-        sys.stderr.write("Extraneous arguments: %s\n" % args)
-        sys.exit(3)
+    args.pids_to_show = []
+    if args.pids:
+        try:
+            args.pids_to_show = [int(x) for x in args.pids.split(',')]
+        except ValueError:
+            parser.error('Invalid PID(s): %s' % args.pids)
 
-    # ps_mem.py options
-    split_args = False
-    pids_to_show = None
-    discriminate_by_pid = False
-    show_swap = False
-    watch = None
-    only_total = False
-
-    for o, a in opts:
-        if o in ('-s', '--split-args'):
-            split_args = True
-        if o in ('-t', '--total'):
-            only_total = True
-        if o in ('-d', '--discriminate-by-pid'):
-            discriminate_by_pid = True
-        if o in ('-S', '--swap'):
-            show_swap = True
-        if o in ('-h', '--help'):
-            sys.stdout.write(help())
-            sys.exit(0)
-        if o in ('--version'):
-            sys.stdout.write('3.13'+'\n')
-            sys.exit(0)
-        if o in ('-p',):
-            try:
-                pids_to_show = [int(x) for x in a.split(',')]
-            except:
-                sys.stderr.write(help())
-                sys.exit(3)
-        if o in ('-w',):
-            try:
-                watch = int(a)
-            except:
-                sys.stderr.write(help())
-                sys.exit(3)
+    if args.watch is not None:
+        if args.watch <= 0:
+            parser.error('Seconds must be positive! (%s)' % args.watch)
 
     return (
-        split_args,
-        pids_to_show,
-        watch,
-        only_total,
-        discriminate_by_pid,
-        show_swap
+        args.split_args,
+        args.pids_to_show,
+        args.watch,
+        args.only_total,
+        args.discriminate_by_pid,
+        args.show_swap,
     )
 
 

--- a/ps_mem.py
+++ b/ps_mem.py
@@ -149,7 +149,12 @@ proc = Proc()
 def parse_options():
     help_msg = 'Show program core memory usage.'
     parser = argparse.ArgumentParser(prog='ps_mem', description=help_msg)
-    parser.add_argument('--version', action='version', version='3.13')
+    parser.add_argument(
+        '--version',
+        action='version',
+        version='3.13',
+        help=argparse.SUPPRESS,
+    )
     parser.add_argument(
         '-s', '--split-args',
         action='store_true',

--- a/ps_mem.py
+++ b/ps_mem.py
@@ -207,24 +207,6 @@ def parse_options():
     )
 
 
-def help():
-    help_msg = 'Usage: ps_mem [OPTION]...\n' \
-        'Show program core memory usage\n' \
-        '\n' \
-        '  -h, -help                   Show this help\n' \
-        '  -p <pid>[,pid2,...pidN]     Only show memory usage PIDs in the '\
-        'specified list\n' \
-        '  -s, --split-args            Show and separate by, all command line'\
-        ' arguments\n' \
-        '  -t, --total                 Show only the total value\n' \
-        '  -d, --discriminate-by-pid   Show by process rather than by program\n' \
-        '  -S, --swap                  Show swap information\n' \
-        '  -w <N>                      Measure and show process memory every'\
-        ' N seconds\n'
-
-    return help_msg
-
-
 # (major,minor,release)
 def kernel_ver():
     kv = proc.open('sys/kernel/osrelease').readline().split(".")[:3]

--- a/ps_mem.py
+++ b/ps_mem.py
@@ -181,6 +181,7 @@ def parse_options():
     parser.add_argument(
         '-w',
         dest='watch',
+        metavar='<N>',
         type=int,
         help='Measure and show process memory every N seconds',
     )


### PR DESCRIPTION
Here's another attempt at moving from getopt to [argparse](https://docs.python.org/3/library/argparse.html), since [the previous one](https://github.com/pixelb/ps_mem/pull/48) by @SayonB was never accepted.

I have tried to make this as clean as possible, but still look basically the same, and use the same variable names internally. I try to make as much use as possible of all the validation and functionality that you get for free with argparse.

* I've changed essentially no functionality, since I have only touched the `parse_options()` function. Here are some minor differences:
  * On all parsing errors, argparse exits with a status code of 2 instead of 3, as the original script does. Since code 2 is only used currently when `/proc` is unavailable, this shouldn't be a big problem.
  * Similary to @SayonB, I validate the `-w` flag to make sure we have a positive number of seconds.
* I removed the `help()` function, and let argparse auto-generate the usage and option help message. See below; it is a few lines longer, but it looks essentially the same.

Here's the new `--help` output, generated by argparse:
```
usage: ps_mem [-h] [-s] [-t] [-d] [-S] [-p <pid>[,pid2,...pidN]] [-w <N>]

Show program core memory usage.

optional arguments:
  -h, --help            show this help message and exit
  -s, --split-args      Show and separate by, all command line arguments
  -t, --total           Show only the total value
  -d, --discriminate-by-pid
                        Show by process rather than by program
  -S, --swap            Show swap information
  -p <pid>[,pid2,...pidN]
                        Only show memory usage PIDs in the specified list
  -w <N>                Measure and show process memory every N seconds
```