### PR TITLE
fix/kernel_version_4.x_mem_counting_failed - issue/#64

### DIFF
--- a/ps_mem.py
+++ b/ps_mem.py
@@ -251,7 +251,11 @@ def getMemStats(pid):
         # not always different for separate processes.
         mem_id = hash(''.join(lines))
         for line in lines:
-            if line.startswith("Shared"):
+            if line.startswith("Private_Hugetlb"):
+                continue
+            elif line.startswith("Shared_Hugetlb"):
+                continue
+            elif line.startswith("Shared"):
                 Shared_lines.append(line)
             elif line.startswith("Private"):
                 Private_lines.append(line)


### PR DESCRIPTION
when the linux kernel version >=4.x , /proc/[pid]/smaps_rollup add new  arguments.

According to the Linux kernel documentation, the two new parameters (Private_hugetlb, Share_hugetlb) will not be added to Pss or Rss, nor will they be added to Private or Share (regardless of whether they are Clean or Dirty).

https://www.kernel.org/doc/html/latest/filesystems/proc.html?highlight=private_hugetlb
<img width="1313" alt="image" src="https://user-images.githubusercontent.com/29141199/101978028-e29d9c00-3c8c-11eb-86df-c5901308db01.png">
