### PR TITLE
python-3.6+ flush check raises return code 120

### DIFF
--- a/ps_mem.py
+++ b/ps_mem.py
@@ -78,6 +78,7 @@ import errno
 import os
 import sys
 import time
+import io
 
 # The following exits cleanly on Ctrl-C or EPIPE
 # while treating other exceptions as before.
@@ -101,16 +102,15 @@ our_pid = os.getpid()
 have_pss = 0
 have_swap_pss = 0
 
-class Unbuffered(object):
+class Unbuffered(io.TextIOBase):
    def __init__(self, stream):
+       super().__init__()
        self.stream = stream
    def write(self, data):
        self.stream.write(data)
        self.stream.flush()
    def close(self):
        self.stream.close()
-   def flush(self):
-      self.stream.flush()
 
 class Proc:
     def __init__(self):


### PR DESCRIPTION
Since python 3.6, output is sanitized during interpreter exit.
Because Unbuffered() inherits from 'object', not every method from
TextIOBase is implemented and this causes python setting return
code to 120.
This was spotted in our CI and is a common issue with IO wrappers
inheriting from simple 'object'.

(Python maintainer stated that the previous implementation might
have always failed, but it was not sanitized until python-3.6.)