### PR TITLE
Convert shebang to `python3`

### DIFF
--- a/ps_mem.py
+++ b/ps_mem.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Try to determine how much RAM is currently being used per program.
 # Note per _program_, not per process. So for example this script


### PR DESCRIPTION
The current shebang leaves the Python version up to the O/S default version.

Since ps_mem doesn't work on Python 2 though, executing it on systems where Python 2 is the default (e.g. Ubuntu) will result in an error:

```sh
$ ./ps_mem.py --help
Traceback (most recent call last):
  File "./ps_mem.py", line 666, in <module>
    if __name__ == '__main__': main()
  File "./ps_mem.py", line 613, in main
    sys.stdout = Unbuffered(sys.stdout)
  File "./ps_mem.py", line 107, in __init__
    super().__init__()
TypeError: super() takes at least 1 argument (0 given)
```

While the project README doesn't specify the requirements, the specific Python 2 incompatible line was introduced on 78e330bf915e9dc39dfa2640bc176828773b9c9c, which seems to assume Python 3.

Feel free to close straight away if Python 2 is still supported, although in this case, a separate issue should be created.