### PR TITLE
FIX Merge more children PIDs to parents (fixes #72, maybe affects  #14)

### DIFF
--- a/ps_mem.py
+++ b/ps_mem.py
@@ -301,7 +301,7 @@ def getMemStats(pid):
     return (Private, Shared, Shared_huge, Swap, mem_id)
 
 
-def getCmdName(pid, split_args, discriminate_by_pid, exe_only=False):
+def getCmdName(pid, split_args, discriminate_by_pid):
     cmdline = proc.open(pid, 'cmdline').read().split("\0")
     while cmdline[-1] == '' and len(cmdline) > 1:
         cmdline = cmdline[:-1]
@@ -334,8 +334,8 @@ def getCmdName(pid, split_args, discriminate_by_pid, exe_only=False):
                 path = cmdline[0] + " [updated]"
             else:
                 path += " [deleted]"
+
     exe = os.path.basename(path)
-    if exe_only: return exe
 
     proc_status = proc.open(pid, 'status').readlines()
     cmd = proc_status[0][6:-1]
@@ -356,17 +356,20 @@ def getCmdName(pid, split_args, discriminate_by_pid, exe_only=False):
                 break
         if ppid:
             try:
-                p_exe = getCmdName(ppid, False, False, exe_only=True)
+                p_exe = getCmdName(ppid, False, False)
             except LookupError:
                 pass
             else:
                 if exe == p_exe:
                     cmd = exe
+
     if sys.version_info >= (3,):
         cmd = cmd.encode(errors='replace').decode()
     if discriminate_by_pid:
         cmd = '%s [%d]' % (cmd, pid)
-    return cmd
+        return cmd
+    else:
+        return exe
 
 
 #The following matches "du -h" output


### PR DESCRIPTION
the algorithm was faulty and returned the command name too early for the old `exe_only` condition, which meant that it did not enjoy the merging up to parents that `discriminate_by_pid` had:

before:
```
    1.1 GiB +   1.9 MiB =   1.1 GiB	WebExtensions         
    5.2 GiB + 871.5 KiB =   5.2 GiB	Privileged Cont       
    6.6 GiB + 297.6 MiB =   6.9 GiB	firefox-esr (23)
    8.9 GiB +   1.1 GiB =  10.0 GiB	chrome (137)
   19.6 GiB + 321.8 MiB =  19.9 GiB	firefox (48)
   36.6 GiB +  13.1 MiB =  36.6 GiB	Isolated Web Co (30)  
```


after:

```
    6.6 GiB + 297.6 MiB =   6.9 GiB	firefox-esr (23)
    8.9 GiB +   1.0 GiB =  10.0 GiB	chrome (137)
   62.6 GiB + 338.8 MiB =  63.0 GiB	firefox (86)
```
